### PR TITLE
Fix shorten URL deletion, add custom URIs

### DIFF
--- a/server/client/js/short.js
+++ b/server/client/js/short.js
@@ -1,6 +1,7 @@
 document.addEventListener("DOMContentLoaded", function () {
 	const fields = {
-		target: document.getElementById("target")
+		target: document.getElementById("target"),
+		uri: document.getElementById("uri")
 	};
 	const form = document.getElementsByClassName("form")[0];
 
@@ -11,6 +12,9 @@ document.addEventListener("DOMContentLoaded", function () {
 			const res = await Api.post("/links/", {
 				headers: {
 					"shorten-url": targetUrl
+				},
+				body: {
+					tag: fields.uri.value || undefined
 				}
 			});
 			if (res.error) {

--- a/server/client/pages/short.ejs
+++ b/server/client/pages/short.ejs
@@ -37,7 +37,7 @@
                     <div class="field">
                         <label class="label" for="target">Custom URI <small>(Optional)</small></label>
                         <div class="control">
-                            <input class="input" type="text" placeholder="SpecialShortcut" id="uri" max="20" min="2" required>
+                            <input class="input" type="text" placeholder="SpecialShortcut" id="uri" max="20" min="2">
                             <small class="help">If specified, must be alpha-numberic and more than 2 characters. Leave blank for a generated ending.</small>
                         </div>
                     </div>

--- a/server/client/pages/short.ejs
+++ b/server/client/pages/short.ejs
@@ -34,6 +34,14 @@
                         </div>
                     </div>
 
+                    <div class="field">
+                        <label class="label" for="target">Custom URI <small>(Optional)</small></label>
+                        <div class="control">
+                            <input class="input" type="text" placeholder="SpecialShortcut" id="uri" max="20" min="2" required>
+                            <small class="help">If specified, must be alpha-numberic and more than 2 characters. Leave blank for a generated ending.</small>
+                        </div>
+                    </div>
+
 
                     <div class="field">
                         <div class="control">


### PR DESCRIPTION
This PR:
- Fixes the bug where a non-root user could not delete url shortenings
- Adds the ability for you to specify the URI (DOMAIN/XXXX) for a given URL shortening.
Given some people may give (less) trusted people access, this has some safeguards:
  - Must be between 2 and 20 characters
  - Must be alphanumeric
  - You cannot overwrite existing URL shortenings

If any of these requirements are failed, a generated URI is returned (as if no custom was specified)

Closes #13, Closes #6 