### PR TITLE
Fix rate limiting for non-cloudflare

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,13 @@ Please note that you must ensure that your proxy passes the `host` and `X-Forwar
             proxy_set_header X-Forwarded-Proto $scheme;
         }
     }
+ 
+### Environment variables
+| Name | Type | Default | Desc |
+| ---- | ---- | ------- | ---- |
+| port | number | 80 | Defines the port Save-Server will listen on. |
+| cloudflare_limiting | boolean | false | Set to `true` to require the use of Cloudflare, so `connecting_ip` exists. If you use Cloudflare and do not enable this, rate limiting may not function as expected. |
+
 ## About
 Each user is allocated a token. This token is used both to authenticate ShareX uploads and web panel access, through a cookie. This server features a rest API.
 

--- a/server/middleware/ratelimit.js
+++ b/server/middleware/ratelimit.js
@@ -72,10 +72,9 @@ setInterval(() => {
 function getIp(req) {
 	const ip = req.get("CF-Connecting-IP");
 	if (!ip) {
-		if (process.env.NODE_ENV === "production") {
+		if (process.env.NODE_ENV === "production" && process.env.cloudflare_limiting === "true") {
 			throw new Error("No Cloudflare IP available");
 		} else {
-			console.log("Falling back to IP");
 			return req.ip;
 		}
 	}

--- a/server/middleware/ratelimit.js
+++ b/server/middleware/ratelimit.js
@@ -72,7 +72,8 @@ setInterval(() => {
 function getIp(req) {
 	const ip = req.get("CF-Connecting-IP");
 	if (!ip) {
-		if (process.env.NODE_ENV === "production" && process.env.cloudflare_limiting === "true") {
+		const cloudflare = process.env.cloudflare_limiting;
+		if (process.env.NODE_ENV === "production" && (cloudflare === "true" || cloudflare === true)) {
 			throw new Error("No Cloudflare IP available");
 		} else {
 			return req.ip;


### PR DESCRIPTION
Instead of assuming Cloudflare is in use, the variable `cloudflare_limiting` should be used to enable rate limiting based on Cloudflare IP.

Otherwise, rate limiting behind proxies such as NGINX and Cloudflare may not function as expected.